### PR TITLE
Drop support for node < 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: '8'
+node_js: '10'
 
 before_install:
 - npm install -g npm@latest

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
Percy requires node >= 10
jsonresume/[resume-cli|registry-functions] support >= 10